### PR TITLE
chore: hourly Agent* package repin

### DIFF
--- a/Agent.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Agent.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -34,7 +34,7 @@
       "location" : "https://github.com/macOS26/AgentD1F.git",
       "state" : {
         "revision" : "2f65032044581b21d8686be9ddbacd1839d3cbb2",
-        "version" : "1.0.2"
+        "version" : "1.0.3"
       }
     },
     {
@@ -70,7 +70,7 @@
       "location" : "https://github.com/macOS26/AgentSwift.git",
       "state" : {
         "revision" : "6e58d69eadfa7e9f72dd6e505aa04c27f2df0f86",
-        "version" : "1.1.0"
+        "version" : "1.1.1"
       }
     },
     {
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/macOS26/AgentTerminalNeo.git",
       "state" : {
-        "revision" : "39cd40955d235445fdb9a9f8281678c2ae93271a",
-        "version" : "1.37.1"
+        "revision" : "8f94990875c1f680c607c74132eafd63e44e8686",
+        "version" : "1.37.2"
       }
     },
     {
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/macOS26/AgentTools.git",
       "state" : {
-        "revision" : "5f5e43142dbb71292af3809c14dae1443c7aa25a",
-        "version" : "2.51.5"
+        "revision" : "f810f7b4d7afaa2ae8d0ab2a7b405aeb521bc587",
+        "version" : "2.51.6"
       }
     },
     {


### PR DESCRIPTION
## Summary

Four Agent* packages had a newer semver tag at HEAD than what `Package.resolved` was pinned to. In every case `HEAD == latest_tag_sha` (no untagged commits), so **no new tags were created** — only the `version` + `revision` fields in `Package.resolved` are updated.

| Package | Old pin | New pin | Revision change? |
|---------|---------|---------|-----------------|
| AgentD1F | 1.0.2 | **1.0.3** | no (same commit) |
| AgentSwift | 1.1.0 | **1.1.1** | no (same commit) |
| AgentTerminalNeo | 1.37.1 | **1.37.2** | yes (`39cd4095` → `8f949908`) |
| AgentTools | 2.51.5 | **2.51.6** | yes (`5f5e4314` → `f810f7b4`) |

Seven other packages (AgentAccess, AgentAudit, AgentColorSyntax, AgentEventBridges, AgentLLM, AgentMCP, and AgentSwift's revision) were already clean. AgentScripts is not a direct dependency of Agent and was not touched.

## ⚠️ xcodebuild not verified

This audit ran in a Linux sandbox where `xcodebuild` is unavailable. **Merging should be gated on a green macOS CI build** to confirm the new pins resolve correctly before landing.

## Test plan

- [ ] macOS CI build passes (`xcodebuild -project Agent.xcodeproj -scheme Agent -configuration Debug -destination 'platform=macOS' build`)
- [ ] Verify Package.resolved has no unexpected diffs beyond the four changed pins