### PR TITLE
chore: hourly Agent* package repin

### DIFF
--- a/Agent.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Agent.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -34,7 +34,7 @@
       "location" : "https://github.com/macOS26/AgentD1F.git",
       "state" : {
         "revision" : "2f65032044581b21d8686be9ddbacd1839d3cbb2",
-        "version" : "1.0.2"
+        "version" : "1.0.3"
       }
     },
     {
@@ -70,7 +70,7 @@
       "location" : "https://github.com/macOS26/AgentSwift.git",
       "state" : {
         "revision" : "6e58d69eadfa7e9f72dd6e505aa04c27f2df0f86",
-        "version" : "1.1.0"
+        "version" : "1.1.1"
       }
     },
     {
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/macOS26/AgentTerminalNeo.git",
       "state" : {
-        "revision" : "39cd40955d235445fdb9a9f8281678c2ae93271a",
-        "version" : "1.37.1"
+        "revision" : "8f94990875c1f680c607c74132eafd63e44e8686",
+        "version" : "1.37.2"
       }
     },
     {
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/macOS26/AgentTools.git",
       "state" : {
-        "revision" : "5f5e43142dbb71292af3809c14dae1443c7aa25a",
-        "version" : "2.51.5"
+        "revision" : "f810f7b4d7afaa2ae8d0ab2a7b405aeb521bc587",
+        "version" : "2.51.6"
       }
     },
     {


### PR DESCRIPTION
## Summary

Automated hourly audit of the macOS26/Agent* Swift-package ecosystem (2026-04-18). Four packages had stale pins in `Package.resolved`; seven were clean. No package had untagged commits past its latest tag, so no new tags were cut.

### Packages repinned

| Package | Old pin | New pin | Revision change |
|---------|---------|---------|----------------|
| AgentD1F | 1.0.2 | **1.0.3** | none (same commit `2f65032`) — 1.0.3 is a lightweight tag at the same commit as the 1.0.2 annotated tag |
| AgentSwift | 1.1.0 | **1.1.1** | none (same commit `6e58d69`) — 1.1.1 is a lightweight tag at the same commit as the 1.1.0 annotated tag |
| AgentTerminalNeo | 1.37.1 | **1.37.2** | `39cd409` → `8f94990` |
| AgentTools | 2.51.5 | **2.51.6** | `5f5e431` → `f810f7b` |

### Packages already clean (no action)

AgentAccess 2.10.2 · AgentAudit 1.2.0 · AgentColorSyntax 1.2.1 · AgentEventBridges 1.1.0 · AgentLLM 1.0.1 · AgentMCP 1.6.1

### AgentScripts

Not a direct dependency of Agent (absent from Package.resolved). Remote is clean: HEAD == latest tag 1.0.6 (`c2a0450`). No action required.

## Build verification

⚠️ `xcodebuild` verification could not be run: the audit sandbox is Linux. **Do not merge until macOS CI confirms the new pins resolve correctly.**

## Test plan

- [ ] macOS CI passes (SwiftPM resolves all four updated pins without error)
- [ ] No regression in other dependencies