### PR TITLE
chore: hourly Agent* package repin

### DIFF
--- a/Agent.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Agent.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/macOS26/AgentTools.git",
       "state" : {
-        "revision" : "f810f7b4d7afaa2ae8d0ab2a7b405aeb521bc587",
-        "version" : "2.51.6"
+        "revision" : "61624cff6658476ac6ff8ad53f4d9c1823d8ee9c",
+        "version" : "2.51.7"
       }
     },
     {


### PR DESCRIPTION
## Summary

Automated hourly repin audit of the macOS26/Agent* Swift-package ecosystem (2026-04-23).

- **AgentTools** repinned `2.51.6 → 2.51.7` — tag `2.51.7` (`61624cff`) was published at HEAD on the default branch; the resolved file still referenced `2.51.6` (`f810f7b4`). This is a pure pin update: revision now matches the latest tagged commit.

## Packages audited (11)

| Package | Latest tag | tag == HEAD | Pin matches latest | Action |
|---------|-----------|-------------|--------------------|--------|
| AgentAccess | 2.10.3 | ✅ | ✅ | none |
| AgentAudit | 1.2.0 | ✅ | ✅ | none |
| AgentColorSyntax | 1.2.1 | ✅ | ✅ | none |
| AgentD1F | 1.0.3 | ✅ | ✅ | none |
| AgentEventBridges | 1.1.0 | ✅ | ✅ | none |
| AgentLLM | 1.0.1 | ✅ | ✅ | none |
| AgentMCP | 1.6.1 | ✅ | ✅ | none |
| AgentScripts | 1.0.6 | ✅ | N/A (not in resolved) | none |
| AgentSwift | 1.1.1 | ✅ | ✅ | none |
| AgentTerminalNeo | 1.37.2 | ✅ | ✅ | none |
| AgentTools | **2.51.7** | ✅ | ❌ (was 2.51.6) | **repinned** |

## Build verification

⚠️ `xcodebuild` is unavailable in the Linux audit sandbox — the build verification step could not run. **Please run `xcodebuild -project Agent.xcodeproj -scheme Agent -configuration Debug -destination 'platform=macOS' build` locally before merging** to confirm the new pin resolves cleanly. Do not force-merge without this check.

## Notes

- **AgentScripts** (`latest: 1.0.6`, HEAD == tag) is not referenced in `Package.resolved`. This is informational — no pin action was taken.
- Two minor tag anomalies noted (no action required): AgentD1F tags `1.0.2` (annotated) and `1.0.3` (lightweight) resolve to the same commit SHA; AgentEventBridges tags `1.0.6` and `1.1.0` also share the same commit SHA.

https://claude.ai/code/session_01PCB6ht7x16pDfxXnYQBeSX

---
_Generated by [Claude Code](https://claude.ai/code/session_01PCB6ht7x16pDfxXnYQBeSX)_