### PR TITLE
chore: hourly Agent* package repin

### DIFF
--- a/Agent.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Agent.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/macOS26/AgentTools.git",
       "state" : {
-        "revision" : "f810f7b4d7afaa2ae8d0ab2a7b405aeb521bc587",
-        "version" : "2.51.6"
+        "revision" : "61624cff6658476ac6ff8ad53f4d9c1823d8ee9c",
+        "version" : "2.51.7"
       }
     },
     {

--- a/Agent.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Agent.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/macOS26/AgentTools.git",
       "state" : {
-        "revision" : "61624cff6658476ac6ff8ad53f4d9c1823d8ee9c",
-        "version" : "2.51.7"
+        "revision" : "bf88384af6ef48a37ad14592f4bb66888ff1f29f",
+        "version" : "2.51.8"
       }
     },
     {


### PR DESCRIPTION
## Summary

Automated hourly repin audit of all 11 macOS26/Agent* Swift packages.

**One package required a pin update (supersedes earlier 2.51.7 commit on this branch):**

| Package | Old version | New version | Old revision | New revision |
|---------|-------------|-------------|--------------|--------------|
| AgentTools | 2.51.6 | **2.51.8** | `f810f7b` | `bf88384` |

AgentTools had two new patch tags (`2.51.7`, `2.51.8`) published past the pinned revision `f810f7b` (2.51.6). Tag `2.51.8` is exactly at HEAD — no untagged commits. This PR advances the pin directly to `2.51.8`.

**All other in-scope packages are CLEAN (tag == HEAD == pin):**

| Package | Latest tag | tag SHA == HEAD | pin version == latest | pin revision == tag SHA |
|---------|------------|-----------------|----------------------|------------------------|
| AgentAccess | 2.10.3 | ✅ | ✅ | ✅ (06a791a) |
| AgentAudit | 1.2.0 | ✅ | ✅ | ✅ (52f1e1b) |
| AgentColorSyntax | 1.2.1 | ✅ | ✅ | ✅ (dfa4f68) |
| AgentD1F | 1.0.3 | ✅ | ✅ | ✅ (2f65032) |
| AgentEventBridges | 1.1.0 | ✅ | ✅ | ✅ (324a987) |
| AgentLLM | 1.0.1 | ✅ | ✅ | ✅ (f2629bf) |
| AgentMCP | 1.6.1 | ✅ | ✅ | ✅ (dcd400e) |
| AgentSwift | 1.1.1 | ✅ | ✅ | ✅ (6e58d69) |
| AgentTerminalNeo | 1.37.2 | ✅ | ✅ | ✅ (8f94990) |

## ⚠️ Separate issue — AgentScripts (requires manual follow-up, NOT in this PR)

`macOS26/AgentScripts` is healthy on the remote (HEAD == tag `1.0.6` at `c2a0450`, no untagged commits), but it has **no entry in `Package.resolved`** and is therefore not a declared SPM dependency of Agent. Adding it requires editing `Package.swift` (source code), which is outside the scope of an automated repin. Please create a separate PR to add `AgentScripts` as a dependency if it is intentionally part of the ecosystem.

## ⚠️ Build verification

`xcodebuild` is unavailable in the Linux audit sandbox. Please verify before merging:

```
xcodebuild -project Agent.xcodeproj -scheme Agent -configuration Debug \
  -destination 'platform=macOS' build
```

## Test plan

- [ ] Run the xcodebuild command above on macOS and confirm exit 0
- [ ] Confirm `Package.resolved` resolves to `AgentTools` tag `2.51.8` in Xcode's Package Dependencies pane
- [ ] No other packages show unexpected version changes
- [ ] File a follow-up ticket for AgentScripts missing from Package.resolved