### PR TITLE
chore: hourly Agent* package repin

### DIFF
--- a/Agent.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Agent.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/macOS26/AgentTools.git",
       "state" : {
-        "revision" : "f810f7b4d7afaa2ae8d0ab2a7b405aeb521bc587",
-        "version" : "2.51.6"
+        "revision" : "61624cff6658476ac6ff8ad53f4d9c1823d8ee9c",
+        "version" : "2.51.7"
       }
     },
     {

--- a/Agent.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Agent.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/macOS26/AgentTools.git",
       "state" : {
-        "revision" : "61624cff6658476ac6ff8ad53f4d9c1823d8ee9c",
-        "version" : "2.51.7"
+        "revision" : "bf88384af6ef48a37ad14592f4bb66888ff1f29f",
+        "version" : "2.51.8"
       }
     },
     {


### PR DESCRIPTION
## Summary

- Repins **AgentTools** from `2.51.6` → `2.51.8` (two patch releases behind; `2.51.7` and `2.51.8` are both tagged, HEAD is at `2.51.8` / `bf88384`)
- All other 9 SwiftPM-pinned packages are already at their latest tagged releases — no changes needed
- `AgentScripts` is a runtime git-clone target (not a SwiftPM dependency); its hardcoded release in `ScriptService.swift` (`1.0.6`) matches the latest tag and HEAD — no action needed

## Audit result (2026-04-23)

| Package | Latest tag | tag==HEAD | Pin matches | Action |
|---|---|---|---|---|
| AgentAccess | 2.10.3 | ✅ | ✅ | CLEAN |
| AgentAudit | 1.2.0 | ✅ | ✅ | CLEAN |
| AgentColorSyntax | 1.2.1 | ✅ | ✅ | CLEAN |
| AgentD1F | 1.0.3 | ✅ | ✅ | CLEAN |
| AgentEventBridges | 1.1.0 | ✅ | ✅ | CLEAN |
| AgentLLM | 1.0.1 | ✅ | ✅ | CLEAN |
| AgentMCP | 1.6.1 | ✅ | ✅ | CLEAN |
| AgentScripts | 1.0.6 | ✅ | n/a (runtime clone) | CLEAN |
| AgentSwift | 1.1.1 | ✅ | ✅ | CLEAN |
| AgentTerminalNeo | 1.37.2 | ✅ | ✅ | CLEAN |
| **AgentTools** | **2.51.8** | ✅ | ❌ was 2.51.6 | **REPINNED** |

## Test plan

- [ ] Verify `Package.resolved` diff is exactly the two-line AgentTools version+revision change
- [ ] Open project in Xcode on macOS and confirm SwiftPM resolves without errors (`File → Packages → Resolve Package Versions`)
- [ ] Build scheme `Agent` for macOS Debug and confirm no compilation errors introduced by AgentTools 2.51.8

> Note: `xcodebuild` is unavailable in the Linux audit sandbox — please verify the build on macOS before merging.