### PR TITLE
chore: hourly Agent* package repin

### DIFF
--- a/Agent.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Agent.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/macOS26/AgentTools.git",
       "state" : {
-        "revision" : "f810f7b4d7afaa2ae8d0ab2a7b405aeb521bc587",
-        "version" : "2.51.6"
+        "revision" : "61624cff6658476ac6ff8ad53f4d9c1823d8ee9c",
+        "version" : "2.51.7"
       }
     },
     {


### PR DESCRIPTION
## Summary

- **AgentTools** 2.51.6 → 2.51.7: tag `2.51.7` was published at HEAD (`61624cff`) but `Package.resolved` was still pinned to `2.51.6` (`f810f7b4`). This is a pure semver bump to an already-published, tagged, lightweight commit — no source changes required.
- All other 9 in-scope Agent\* packages are **CLEAN** (tag SHA == HEAD SHA == pinned revision).
- **AgentScripts** (in audit scope) has no pin in `Package.resolved` and is not a direct dependency of Agent — no action taken.

## Audit details (2026-04-23T UTC)

| Package | Latest tag | tag==HEAD | pin matches | Action |
|---|---|---|---|---|
| AgentAccess | 2.10.3 | ✅ | ✅ 2.10.3 | none |
| AgentAudit | 1.2.0 | ✅ | ✅ 1.2.0 | none |
| AgentColorSyntax | 1.2.1 | ✅ | ✅ 1.2.1 | none |
| AgentD1F | 1.0.3 | ✅ | ✅ 1.0.3 | none |
| AgentEventBridges | 1.1.0 | ✅ | ✅ 1.1.0 | none |
| AgentLLM | 1.0.1 | ✅ | ✅ 1.0.1 | none |
| AgentMCP | 1.6.1 | ✅ | ✅ 1.6.1 | none |
| AgentScripts | 1.0.6 | ✅ | *(not a dep)* | none |
| AgentSwift | 1.1.1 | ✅ | ✅ 1.1.1 | none |
| AgentTerminalNeo | 1.37.2 | ✅ | ✅ 1.37.2 | none |
| **AgentTools** | **2.51.7** | ✅ | ❌ was 2.51.6 | **repinned** |

## Build verification

`xcodebuild` is not available in the Linux audit sandbox. The pin change is mechanically sound (well-formed JSON, existing published tag, SHA verified against `git ls-remote`). Please run a local `xcodebuild -project Agent.xcodeproj -scheme Agent -configuration Debug -destination 'platform=macOS' build` before merging to confirm package resolution.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SJ6k2r9Mu8tjK64w7yaYow)_