### PR TITLE
chore: hourly Agent* package repin

### DIFF
--- a/Agent.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Agent.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/macOS26/AgentTools.git",
       "state" : {
-        "revision" : "f810f7b4d7afaa2ae8d0ab2a7b405aeb521bc587",
-        "version" : "2.51.6"
+        "revision" : "61624cff6658476ac6ff8ad53f4d9c1823d8ee9c",
+        "version" : "2.51.7"
       }
     },
     {


### PR DESCRIPTION
## Summary

- Repins **AgentTools** from `2.51.6` (`f810f7b4`) → `2.51.7` (`61624cff`)
- 10 of 11 audited packages were already clean (tag == HEAD == pin)
- AgentScripts is not a declared dependency of this project and needs no pin

## Audit results

| Package | Latest Tag | Tag==HEAD | Pin matched | Action |
|---|---|---|---|---|
| AgentAccess | 2.10.3 | ✅ | ✅ | CLEAN |
| AgentAudit | 1.2.0 | ✅ | ✅ | CLEAN |
| AgentColorSyntax | 1.2.1 | ✅ | ✅ | CLEAN |
| AgentD1F | 1.0.3 | ✅ | ✅ | CLEAN |
| AgentEventBridges | 1.1.0 | ✅ | ✅ | CLEAN |
| AgentLLM | 1.0.1 | ✅ | ✅ | CLEAN |
| AgentMCP | 1.6.1 | ✅ | ✅ | CLEAN |
| AgentScripts | 1.0.6 | ✅ | N/A (not in project) | NOT A DEP |
| AgentSwift | 1.1.1 | ✅ | ✅ | CLEAN |
| AgentTerminalNeo | 1.37.2 | ✅ | ✅ | CLEAN |
| **AgentTools** | **2.51.7** | ✅ | ❌ was 2.51.6 | **REPINNED** |

## Test plan

- [ ] Run `xcodebuild -project Agent.xcodeproj -scheme Agent -configuration Debug -destination 'platform=macOS' build` on macOS and confirm it succeeds with the new pin before merging
- [ ] Confirm no runtime regressions in AgentTools-dependent features

> ⚠️ Build verification could not be performed during this audit (Linux sandbox, no xcodebuild). **Do not merge until the build check above passes.**

https://claude.ai/code/session_0149fXY9nSzcy4jx4eDqvCAG

---
_Generated by [Claude Code](https://claude.ai/code/session_0149fXY9nSzcy4jx4eDqvCAG)_