### PR TITLE
chore: hourly Agent* package repin

### DIFF
--- a/Agent.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Agent.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/macOS26/AgentTools.git",
       "state" : {
-        "revision" : "f810f7b4d7afaa2ae8d0ab2a7b405aeb521bc587",
-        "version" : "2.51.6"
+        "revision" : "bf88384af6ef48a37ad14592f4bb66888ff1f29f",
+        "version" : "2.51.8"
       }
     },
     {


### PR DESCRIPTION
## Summary

- Repins **AgentTools** from `2.51.6` (`f810f7b`) → `2.51.8` (`bf88384`) — HEAD of the default branch is now tagged at 2.51.8, two patch releases ahead of the stale pin.
- All other 9 audited packages (AgentAccess, AgentAudit, AgentColorSyntax, AgentD1F, AgentEventBridges, AgentLLM, AgentMCP, AgentSwift, AgentTerminalNeo) are **clean**: latest tag == HEAD == pinned revision.

## ⚠️ Build verification required before merge

`xcodebuild` is unavailable in the Linux audit sandbox. Please run the following on macOS before merging:

```
xcodebuild -project Agent.xcodeproj -scheme Agent -configuration Debug \
  -destination 'platform=macOS' build
```

## Audit notes

- **AgentScripts** (`macOS26/AgentScripts`, latest tag `1.0.6` at `c2a045`) is **not present in Package.resolved**. It is in the declared audit scope but is not a current dependency of this project. No action taken — verify intentional omission.
- Several `macOS26/*` repositories returned intermittent HTTP 500 errors during `git ls-remote`; all were successfully retried and verified.

https://claude.ai/code/session_01BdCfU1DwFmrbuuD214W6Qg

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdCfU1DwFmrbuuD214W6Qg)_