### PR TITLE
chore: hourly Agent* package repin

### DIFF
--- a/Agent.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Agent.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/macOS26/AgentTools.git",
       "state" : {
-        "revision" : "f810f7b4d7afaa2ae8d0ab2a7b405aeb521bc587",
-        "version" : "2.51.6"
+        "revision" : "bf88384af6ef48a37ad14592f4bb66888ff1f29f",
+        "version" : "2.51.8"
       }
     },
     {


### PR DESCRIPTION
## Summary

- **AgentTools** repinned `2.51.6` → `2.51.8`
  - Old revision: `f810f7b4d7afaa2ae8d0ab2a7b405aeb521bc587`
  - New revision: `bf88384af6ef48a37ad14592f4bb66888ff1f29f`
  - Tags 2.51.7 and 2.51.8 were published after the last repin; HEAD sits at 2.51.8, which is the latest released tag.

- All other 9 pinned packages were already at their respective latest tags (no change):
  AgentAccess 2.10.3, AgentAudit 1.2.0, AgentColorSyntax 1.2.1, AgentD1F 1.0.3,
  AgentEventBridges 1.1.0, AgentLLM 1.0.1, AgentMCP 1.6.1, AgentSwift 1.1.1,
  AgentTerminalNeo 1.37.2.

- **AgentScripts** carries no Package.resolved pin — confirmed intentional: it is a runtime-cloned resource (see `ScriptService.swift`), not a Swift Package dependency.

## ⚠️ Build Verification

`xcodebuild` was unavailable in the Linux audit sandbox (not an Xcode/macOS host).
**This PR must be verified on a macOS machine** with:

```
xcodebuild -project Agent.xcodeproj -scheme Agent -configuration Debug \
  -destination 'platform=macOS' build
```

Do **not** merge until the build is confirmed green.

## Test plan

- [ ] Pull this branch on a macOS machine and run the xcodebuild command above
- [ ] Confirm Swift Package resolution fetches AgentTools 2.51.8 without errors
- [ ] Confirm no other package pins regressed

https://claude.ai/code/session_017QKfRdrXQCpyGujCoFkHYp

---
_Generated by [Claude Code](https://claude.ai/code/session_017QKfRdrXQCpyGujCoFkHYp)_