### PR TITLE
feat: add Exa AI-powered search tool

### DIFF
--- a/Agent.xcodeproj/project.pbxproj
+++ b/Agent.xcodeproj/project.pbxproj
@@ -197,6 +197,7 @@
 		FF10000000000000000011 /* Speech.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF10000000000000000010 /* Speech.swift */; };
 		FF20000000000000000002 /* SafariWebAutomationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF20000000000000000001 /* SafariWebAutomationTests.swift */; };
 		FF20000000000000000004 /* DiffToolsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF20000000000000000003 /* DiffToolsTests.swift */; };
+		FF20000000000000000006 /* ExaSearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF20000000000000000005 /* ExaSearchTests.swift */; };
 		SS110000000000000000001 /* ScriptService+Metadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = SS110000000000000000002 /* ScriptService+Metadata.swift */; };
 		SS110000000000000000003 /* ScriptService+Execution.swift in Sources */ = {isa = PBXBuildFile; fileRef = SS110000000000000000004 /* ScriptService+Execution.swift */; };
 		SS110000000000000000005 /* ScriptService+SavedScripts.swift in Sources */ = {isa = PBXBuildFile; fileRef = SS110000000000000000006 /* ScriptService+SavedScripts.swift */; };
@@ -459,6 +460,7 @@
 		FF10000000000000000010 /* Speech.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Speech.swift"; sourceTree = "<group>"; };
 		FF20000000000000000001 /* SafariWebAutomationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariWebAutomationTests.swift; sourceTree = "<group>"; };
 		FF20000000000000000003 /* DiffToolsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffToolsTests.swift; sourceTree = "<group>"; };
+		FF20000000000000000005 /* ExaSearchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExaSearchTests.swift; sourceTree = "<group>"; };
 		SS110000000000000000002 /* ScriptService+Metadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ScriptService+Metadata.swift"; sourceTree = "<group>"; };
 		SS110000000000000000004 /* ScriptService+Execution.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ScriptService+Execution.swift"; sourceTree = "<group>"; };
 		SS110000000000000000006 /* ScriptService+SavedScripts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ScriptService+SavedScripts.swift"; sourceTree = "<group>"; };
@@ -616,6 +618,7 @@
 			children = (
 				FF20000000000000000001 /* SafariWebAutomationTests.swift */,
 				FF20000000000000000003 /* DiffToolsTests.swift */,
+				FF20000000000000000005 /* ExaSearchTests.swift */,
 			);
 			path = AgentTests;
 			sourceTree = "<group>";
@@ -1385,6 +1388,7 @@
 			files = (
 				FF20000000000000000002 /* SafariWebAutomationTests.swift in Sources */,
 				FF20000000000000000004 /* DiffToolsTests.swift in Sources */,
+				FF20000000000000000006 /* ExaSearchTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Agent/AgentViewModel/Core/AgentViewModel.swift
+++ b/Agent/AgentViewModel/Core/AgentViewModel.swift
@@ -182,6 +182,11 @@ final class AgentViewModel {
         didSet { KeychainService.shared.setTavilyAPIKey(tavilyAPIKey) }
     }
 
+    // Exa web search API key (available for all providers)
+    var exaAPIKey: String = KeychainService.shared.getExaAPIKey() ?? "" {
+        didSet { KeychainService.shared.setExaAPIKey(exaAPIKey) }
+    }
+
     let ollamaEndpoint = "https://ollama.com/api/chat"
 
     // OpenAI settings

--- a/Agent/AgentViewModel/TaskUtilities/WebSearch.swift
+++ b/Agent/AgentViewModel/TaskUtilities/WebSearch.swift
@@ -19,7 +19,7 @@ extension AgentViewModel {
     /// This delegates to the implementation in AgentViewModel+WebSearch.swift.
     nonisolated static func performWebSearchForTask(query: String, apiKey: String, provider: APIProvider) async -> String {
         // Fallback chain — each step tries a more universal backend: 1. Ollama+key → Ollama Web Search 2.
-        // Z.AI/BigModel+key → Z.AI search-prime 3. Tavily key → Tavily 4. DuckDuckGo HTML scrape (no key, always available)
+        // Z.AI/BigModel+key → Z.AI search-prime 3. Exa key → Exa /search 4. Tavily key → Tavily 5. DuckDuckGo HTML scrape (no key, always available)
         if provider == .ollama || provider == .localOllama {
             if let ollamaKey = KeychainService.shared.getOllamaAPIKey(), !ollamaKey.isEmpty {
                 let ollamaResult = await performOllamaWebSearchInternal(query: query, apiKey: ollamaKey)
@@ -36,6 +36,15 @@ extension AgentViewModel {
                 if !zResult.hasPrefix("Error:") {
                     return zResult
                 }
+            }
+        }
+        // Exa — neural/semantic web search via api.exa.ai. Pulled from
+        // Keychain inside the function (matches Z.AI/Ollama pattern). Falls
+        // through on error so Tavily/DuckDuckGo remain available.
+        if let exaKey = KeychainService.shared.getExaAPIKey(), !exaKey.isEmpty {
+            let exaResult = await performExaSearchInternal(query: query, apiKey: exaKey)
+            if !exaResult.hasPrefix("Error:") {
+                return exaResult
             }
         }
         // Tavily — only attempt if a key is configured. Missing key → skip,
@@ -260,6 +269,102 @@ extension AgentViewModel {
             }
             return "No search results found for '\(query)'"
         } catch { return "Error: \(error.localizedDescription)" }
+    }
+
+    /// Calls Exa's /search endpoint (https://api.exa.ai/search). Exa is a
+    /// neural/semantic web search API; the `auto` type lets the API pick
+    /// neural vs keyword per query. We request both `text` (truncated) and
+    /// `highlights` so the snippet logic can cascade through whichever
+    /// content the API returns. The `x-exa-integration` header tags this
+    /// integration so Exa can attribute usage.
+    nonisolated static func performExaSearchInternal(query: String, apiKey: String) async -> String {
+        guard !apiKey.isEmpty else { return "Error: Exa API key not set. Add it in Settings." }
+        guard let url = URL(string: "https://api.exa.ai/search") else { return "Error: Invalid Exa URL" }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
+        request.setValue("agent", forHTTPHeaderField: "x-exa-integration")
+        request.timeoutInterval = llmAPITimeout
+        let body: [String: Any] = [
+            "query": query,
+            "type": "auto",
+            "numResults": 5,
+            "contents": [
+                "text": ["maxCharacters": 800],
+                "highlights": ["numSentences": 2, "highlightsPerUrl": 2],
+            ],
+        ]
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse else { return "Error: Invalid response from Exa" }
+            guard httpResponse.statusCode == 200 else {
+                let errorBody = String(data: data, encoding: .utf8) ?? "Unknown error"
+                return "Error: Exa API returned \(httpResponse.statusCode): \(errorBody)"
+            }
+            return formatExaResponse(data: data, query: query)
+        } catch { return "Error: \(error.localizedDescription)" }
+    }
+
+    /// Decode an Exa /search response and render it in the same multi-line
+    /// format used by the other providers. Exposed for unit tests so we can
+    /// feed in a hardcoded JSON fixture without hitting the network.
+    nonisolated static func formatExaResponse(data: Data, query: String) -> String {
+        struct ExaSearchResponse: Decodable {
+            let results: [ExaResult]
+        }
+        struct ExaResult: Decodable {
+            let title: String?
+            let url: String?
+            let publishedDate: String?
+            let author: String?
+            let text: String?
+            let highlights: [String]?
+            let summary: String?
+        }
+        do {
+            let decoded = try JSONDecoder().decode(ExaSearchResponse.self, from: data)
+            if decoded.results.isEmpty { return "No search results found for '\(query)'" }
+            var output = ""
+            for (i, result) in decoded.results.enumerated() {
+                let title = result.title?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+                    ? result.title! : "Untitled"
+                let resultUrl = result.url ?? ""
+                output += "\(i + 1). \(title)\n   \(resultUrl)\n"
+                let metaParts = [result.author, result.publishedDate].compactMap { $0 }.filter { !$0.isEmpty }
+                if !metaParts.isEmpty {
+                    output += "   [\(metaParts.joined(separator: " · "))]\n"
+                }
+                let snippet = exaSnippet(highlights: result.highlights, summary: result.summary, text: result.text)
+                if !snippet.isEmpty { output += "   \(snippet)\n" }
+                output += "\n"
+            }
+            return output.trimmingCharacters(in: .whitespacesAndNewlines)
+        } catch {
+            return "Error: Failed to parse Exa response: \(error.localizedDescription)"
+        }
+    }
+
+    /// Cascade through the content modes Exa may return. The API may return
+    /// any combination of highlights/summary/text depending on the request
+    /// and what was indexed for the page; pick the first one that's actually
+    /// populated rather than assuming exactly one will be present.
+    nonisolated static func exaSnippet(highlights: [String]?, summary: String?, text: String?) -> String {
+        if let highlights, !highlights.isEmpty {
+            let joined = highlights
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }
+                .joined(separator: " … ")
+            if !joined.isEmpty { return joined }
+        }
+        if let summary = summary?.trimmingCharacters(in: .whitespacesAndNewlines), !summary.isEmpty {
+            return summary
+        }
+        if let text = text?.trimmingCharacters(in: .whitespacesAndNewlines), !text.isEmpty {
+            return text
+        }
+        return ""
     }
 
     nonisolated private static func performTavilySearchForTask(query: String, apiKey: String) async -> String {

--- a/Agent/Services/KeychainService.swift
+++ b/Agent/Services/KeychainService.swift
@@ -78,6 +78,10 @@ final class KeychainService: Sendable {
     func setOpenRouterAPIKey(_ key: String) { set(key: Self.openRouterAPIKey, value: key) }
     func getOpenRouterAPIKey() -> String? { get(key: Self.openRouterAPIKey) }
 
+    private static let exaAPIKey = "com.agent.exa-api-key"
+    func setExaAPIKey(_ key: String) { set(key: Self.exaAPIKey, value: key) }
+    func getExaAPIKey() -> String? { get(key: Self.exaAPIKey) }
+
     private func set(key: String, value: String) {
         guard let data = value.data(using: .utf8) else { return }
         delete(key: key)

--- a/Agent/Views/Settings/SettingsView.swift
+++ b/Agent/Views/Settings/SettingsView.swift
@@ -1024,13 +1024,18 @@ struct SettingsView: View {
                     }
             }
 
-            // Web Search (Tavily) — available for all providers
+            // Web Search — available for all providers. Exa is preferred when
+            // configured, then Tavily, with DuckDuckGo as the keyless fallback.
             VStack(alignment: .leading, spacing: 10) {
                 Text("Web Search")
                     .font(.headline)
-                Text("Tavily provides web search for all LLM providers.")
+                Text("Exa or Tavily provides web search for all LLM providers. DuckDuckGo is used when neither key is set.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Exa API Key").font(.caption).foregroundStyle(.secondary)
+                    LockedSecureField(text: $viewModel.exaAPIKey, placeholder: "exa-...", lockKey: "lock.exaAPIKey")
+                }
                 VStack(alignment: .leading, spacing: 4) {
                     Text("Tavily API Key").font(.caption).foregroundStyle(.secondary)
                     LockedSecureField(text: $viewModel.tavilyAPIKey, placeholder: "tvly-...", lockKey: "lock.tavilyAPIKey")

--- a/AgentTests/ExaSearchTests.swift
+++ b/AgentTests/ExaSearchTests.swift
@@ -1,0 +1,119 @@
+import Testing
+import Foundation
+@testable import Agent_
+
+/// Unit tests for the Exa search provider helpers in WebSearch.swift.
+/// These tests cover response parsing and snippet fallback. They never
+/// hit the network — `formatExaResponse` is deliberately exposed so we
+/// can feed in hardcoded fixtures.
+@Suite("ExaSearch")
+@MainActor struct ExaSearchTests {
+
+    // MARK: - formatExaResponse
+
+    @Test("Parses standard Exa response with text + highlights")
+    func parsesStandardResponse() throws {
+        let json = #"""
+        {
+          "results": [
+            {
+              "title": "Neural Search Explained",
+              "url": "https://example.com/neural",
+              "publishedDate": "2025-01-15T00:00:00.000Z",
+              "author": "Jane Doe",
+              "text": "Neural search uses embedding models to retrieve semantically relevant pages.",
+              "highlights": ["Neural search uses embeddings to retrieve relevant pages."]
+            }
+          ]
+        }
+        """#
+        let data = Data(json.utf8)
+        let out = AgentViewModel.formatExaResponse(data: data, query: "neural search")
+        #expect(out.contains("1. Neural Search Explained"))
+        #expect(out.contains("https://example.com/neural"))
+        #expect(out.contains("Jane Doe"))
+        #expect(out.contains("2025-01-15"))
+        #expect(out.contains("Neural search uses embeddings"))
+    }
+
+    @Test("Empty results array returns no-results message")
+    func emptyResults() {
+        let json = #"{ "results": [] }"#
+        let out = AgentViewModel.formatExaResponse(data: Data(json.utf8), query: "obscure query")
+        #expect(out.contains("No search results found for 'obscure query'"))
+    }
+
+    @Test("Malformed JSON returns parse error")
+    func malformedJSON() {
+        let out = AgentViewModel.formatExaResponse(data: Data("not json".utf8), query: "x")
+        #expect(out.hasPrefix("Error: Failed to parse Exa response"))
+    }
+
+    @Test("Missing optional fields render gracefully")
+    func missingOptionalFields() {
+        let json = #"""
+        { "results": [ { "url": "https://example.com/x" } ] }
+        """#
+        let out = AgentViewModel.formatExaResponse(data: Data(json.utf8), query: "x")
+        #expect(out.contains("1. Untitled"))
+        #expect(out.contains("https://example.com/x"))
+        // No author/date metadata line
+        #expect(!out.contains("[ · ]"))
+    }
+
+    // MARK: - Snippet fallback (highlights → summary → text)
+
+    @Test("Snippet prefers highlights when present")
+    func snippetPrefersHighlights() {
+        let snippet = AgentViewModel.exaSnippet(
+            highlights: ["First highlight.", "Second highlight."],
+            summary: "Summary text.",
+            text: "Full text content."
+        )
+        #expect(snippet == "First highlight. … Second highlight.")
+    }
+
+    @Test("Snippet falls back to summary when highlights empty")
+    func snippetFallsBackToSummary() {
+        let snippet = AgentViewModel.exaSnippet(
+            highlights: [],
+            summary: "Summary text.",
+            text: "Full text content."
+        )
+        #expect(snippet == "Summary text.")
+    }
+
+    @Test("Snippet falls back to text when highlights and summary missing")
+    func snippetFallsBackToText() {
+        let snippet = AgentViewModel.exaSnippet(
+            highlights: nil,
+            summary: nil,
+            text: "Full text content."
+        )
+        #expect(snippet == "Full text content.")
+    }
+
+    @Test("Snippet returns empty string when nothing populated")
+    func snippetEmpty() {
+        let snippet = AgentViewModel.exaSnippet(highlights: nil, summary: "   ", text: "")
+        #expect(snippet == "")
+    }
+
+    @Test("Snippet skips whitespace-only highlights")
+    func snippetSkipsWhitespaceHighlights() {
+        let snippet = AgentViewModel.exaSnippet(
+            highlights: ["   ", ""],
+            summary: "Summary text.",
+            text: nil
+        )
+        #expect(snippet == "Summary text.")
+    }
+
+    // MARK: - Disabled state
+
+    @Test("Empty API key returns 'not set' error without making a request")
+    func emptyAPIKey() async {
+        let result = await AgentViewModel.performExaSearchInternal(query: "test", apiKey: "")
+        #expect(result == "Error: Exa API key not set. Add it in Settings.")
+    }
+}

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ These are the canonical tool names defined in `AgentTools.Name.*` and exposed to
 |---|---|---|
 | **done** | `summary` | Signal task complete. Required at end of every task |
 | **list_tools** | — | Returns the live tool list for the current provider (built-in + MCP) |
-| **search** | `query` | Web search via Tavily |
+| **search** | `query` | Web search via Exa, Tavily, or DuckDuckGo (whichever key is configured) |
 | **chat** | `write` / `transform` / `fix` / `about` | Write prose, transform/fix text, describe Agent capabilities |
 | **memory** | `read` / `write` / `append` / `clear` | Persistent user preferences. "remember X" → `append` |
 | **plan** | `create` / `update` / `read` / `list` / `delete` | Multi-plan CRUD with per-step status tracking |


### PR DESCRIPTION
## Summary

- Adds [Exa](https://exa.ai) (`api.exa.ai/search`) as a web-search provider, fitting into the existing Tavily / Z.AI / Ollama / DuckDuckGo fallback chain in `performWebSearchForTask`.
- New key is stored in Keychain (`KeychainService.get/setExaAPIKey`) and exposed in Settings next to the existing Tavily field. When configured, Exa is preferred over Tavily; DuckDuckGo remains the keyless fallback.
- Exa is requested with `type: auto` and `contents: { text, highlights }`. A typed `Decodable` response model is decoded, and a `exaSnippet` helper cascades through `highlights → summary → text` so the formatter handles whatever combination Exa returns for a given page.

## Why Exa

Exa's `auto` search type chooses between neural and keyword retrieval per query, which complements the existing keyword-style providers and is useful for the more open-ended research queries the agent often makes. The new field is opt-in and does not change behavior for users who only have a Tavily key set.

## Usage

Open Settings → "Web Search" and paste an Exa key:

```
exa-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
```

Once set, calls through `performWebSearchForTask` (e.g. the `web_search` / `search` tool) hit Exa first.

```swift
// performWebSearchForTask fallback chain:
// 1. Ollama Web Search (if provider == .ollama and key set)
// 2. Z.AI search-prime (if provider in [.zAI, .bigModel] and key set)
// 3. Exa /search (if Exa key set)              ← new
// 4. Tavily /search (if Tavily key passed in)
// 5. DuckDuckGo HTML scrape (always-on fallback)
```

## Files changed

- `Agent/AgentViewModel/TaskUtilities/WebSearch.swift` — new `performExaSearchInternal`, typed response decoder, snippet helper; Exa step inserted into the fallback chain
- `Agent/Services/KeychainService.swift` — `get/setExaAPIKey`
- `Agent/AgentViewModel/Core/AgentViewModel.swift` — `exaAPIKey` property bound to Keychain
- `Agent/Views/Settings/SettingsView.swift` — Exa API key field in the Web Search section
- `Agent.xcodeproj/project.pbxproj` — register `ExaSearchTests.swift` in the AgentTests target
- `AgentTests/ExaSearchTests.swift` — unit tests for response parsing and snippet fallback
- `README.md` — tool table updated to mention Exa/Tavily/DuckDuckGo

## Test plan

- [x] `swiftc -parse` passes on every modified Swift file
- [x] `ExaSearchTests` covers: standard response, empty results, malformed JSON, missing optional fields, snippet cascade (highlights → summary → text), whitespace-only highlight skipping, empty-key guard
- [ ] `xcodebuild -scheme "Agent!" build` (requires full Xcode; my local env only has Command Line Tools, so I couldn't run it — happy to iterate if CI flags anything)
- [ ] `xcodebuild -scheme "Agent!" test` runs the new `ExaSearchTests` suite (same caveat)
- [ ] Manual smoke test: enter an Exa key in Settings, run a `web_search` and confirm Exa results render

## Notes

- No new dependencies — the implementation uses `URLSession` + `JSONDecoder`, matching how the other providers are written.
- All existing providers (Tavily, Z.AI, Ollama, DuckDuckGo) are untouched.