### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/Agent/AgentViewModel/Core/AgentViewModel.swift
+++ b/Agent/AgentViewModel/Core/AgentViewModel.swift
@@ -352,7 +352,7 @@ final class AgentViewModel {
         didSet { KeychainService.shared.setMiniMaxAPIKey(miniMaxAPIKey) }
     }
 
-    var miniMaxModel: String = UserDefaults.standard.string(forKey: "miniMaxModel") ?? "MiniMax-M2.7" {
+    var miniMaxModel: String = UserDefaults.standard.string(forKey: "miniMaxModel") ?? "MiniMax-M3" {
         didSet { UserDefaults.standard.set(miniMaxModel, forKey: "miniMaxModel") }
     }
 

--- a/Agent/AgentViewModel/Features/ModelFetching.swift
+++ b/Agent/AgentViewModel/Features/ModelFetching.swift
@@ -284,7 +284,7 @@ extension AgentViewModel {
                 miniMaxModels = models.isEmpty ? Self.defaultMiniMaxModels : models
                 let ids = miniMaxModels.map(\.id)
                 if miniMaxModel.isEmpty || (!ids.isEmpty && !ids.contains(miniMaxModel)) {
-                    miniMaxModel = ids.first ?? "MiniMax-M2.7"
+                    miniMaxModel = ids.first ?? "MiniMax-M3"
                 }
             } catch {
                 appendLog("Failed to fetch MiniMax models: \(error.localizedDescription)")

--- a/Agent/Views/Tabs/NewMainTabSheet.swift
+++ b/Agent/Views/Tabs/NewMainTabSheet.swift
@@ -308,7 +308,7 @@ struct NewMainTabSheet: View {
         case .lmStudio: return viewModel.lmStudioModel
         case .zAI: return viewModel.zAIModel
         case .bigModel: return "glm-4.7"
-        case .miniMax: return viewModel.miniMaxModel.isEmpty ? "MiniMax-M2.7" : viewModel.miniMaxModel
+        case .miniMax: return viewModel.miniMaxModel.isEmpty ? "MiniMax-M3" : viewModel.miniMaxModel
         case .openRouter: return viewModel.openRouterModel
         case .qwen: return "qwen-plus"
         case .gemini: return viewModel.geminiModel


### PR DESCRIPTION
## Summary
Upgrade the default MiniMax (miniMax) model fallback from `MiniMax-M2.7` to the new flagship `MiniMax-M3`.

## Changes
- `AgentViewModel.swift`: change `miniMaxModel` UserDefaults default to `MiniMax-M3`
- `ModelFetching.swift`: change fallback model ID in `fetchMiniMaxModels()` to `MiniMax-M3` when the `/v1/models` endpoint returns no IDs
- `NewMainTabSheet.swift`: change display fallback to `MiniMax-M3`

## Why
MiniMax-M3 is the latest flagship model. The picker is still populated dynamically from `https://api.minimax.io/v1/models`, so M2.7 remains available for users who prefer it — only the default for fresh installs and unset selections changes.

## Notes
- No new dependencies
- No changes to API URL, TTS config, or keychain key
- Existing users keep their stored `miniMaxModel` selection